### PR TITLE
AS-1225 Disabling "Allow Expansion Bar" causes issues on A14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Group changes to describe their impact on the project, as follows:
     Fixed for any bug fixes.
     Security to invite users to upgrade in case of vulnerabilities.
 
+## [5.2.6] - 2025-03-26
+- Suppress IncomingCall-Notification cause wil be blocked by SOTI Inst…
+- Instead activate Incomming Call screen (AS-1225). 
+
 ## [5.2.5] - 2024-05-03
 
 ## Changed

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,10 +10,10 @@ plugins {
 // Used to set the package version name and version code
 ext.versionMajor = 5
 ext.versionMinor = 2
-ext.versionRelease = 5
+ext.versionRelease = 6
 
-def appVersionName = "5.2.5"
-def appVersionCode = 52005
+def appVersionName = "5.2.6"
+def appVersionCode = 52006
 
 static def getPackageName() {
     return "nl.clb.linphone"

--- a/app/src/main/java/org/linphone/core/CoreContext.kt
+++ b/app/src/main/java/org/linphone/core/CoreContext.kt
@@ -1187,7 +1187,7 @@ class CoreContext(
 
     /* Start call related activities */
 
-    private fun onIncomingReceived() {
+    public fun onIncomingReceived() {
         if (corePreferences.preventInterfaceFromShowingUp) {
             Log.w("[Context] We were asked to not show the incoming call screen")
             return

--- a/app/src/main/java/org/linphone/notifications/NotificationsManager.kt
+++ b/app/src/main/java/org/linphone/notifications/NotificationsManager.kt
@@ -129,7 +129,12 @@ class NotificationsManager(private val context: Context) {
                         Log.i(
                             "[Notifications Manager] Service isn't null, show incoming call notification"
                         )
-                        displayIncomingCallNotification(call, false)
+                        // CLB: Suppress IncomingCall-Notification cause, wil be blocked by SOTI
+                        // Instead just show Incoming call view in App
+                        coreContext.onIncomingReceived()
+
+                        // displayIncomingCallNotification(call, false)
+                        // End CLB
                     } else {
                         Log.w("[Notifications Manager] No service found, waiting for it to start")
                     }


### PR DESCRIPTION
AS-1225 Disabling "Allow Expansion Bar" causes issues on A14

- Suppress IncomingCall-Notification cause wil be blocked by SOTI Inst…
- Instead activate Incomming Call screen 
