### PR TITLE
SS-6851 Linphone settings via any http server

### DIFF
--- a/app/src/main/java/org/linphone/LinphoneApplication.kt
+++ b/app/src/main/java/org/linphone/LinphoneApplication.kt
@@ -133,7 +133,6 @@ class LinphoneApplication : Application(), ImageLoaderFactory {
             // CLB: Try to download file... if it exists... parse the 'app' section ourselves.
             // Linphone SDK provisioning does NOT support app section settings
             if (coreContext.core.provisioningUri != null) {
-
                 val ach = AppConfigHelper(context, corePreferences)
                 var provisioningPath = coreContext.core.provisioningUri
 
@@ -145,7 +144,7 @@ class LinphoneApplication : Application(), ImageLoaderFactory {
 
                 if (contents != null && contents.length > 0) {
                     // If there were any config changes, also update the 'show_settings' value
-                    Log.i("[Application] Applying [app] section provisioning config...");
+                    Log.i("[Application] Applying [app] section provisioning config...")
                     val config = Factory.instance().createConfigWithFactory(
                         corePreferences.configPath,
                         corePreferences.factoryConfigPath
@@ -154,7 +153,8 @@ class LinphoneApplication : Application(), ImageLoaderFactory {
                     if (LinphonePreferencesCLB.instance().UpdateFromLinphoneXmlData(
                             contents,
                             config
-                        )) {
+                        )
+                    ) {
                         ach.updateShowSettingsToCorePreferences(config)
                     }
                 }
@@ -209,7 +209,8 @@ class LinphoneApplication : Application(), ImageLoaderFactory {
                 //    this::class.java.classLoader.getResource("assets/clb_linphonerc_test").readText()
                 if (LinphonePreferencesCLB.instance().UpdateFromLinphoneRcData(
                         linphonercData,
-                        corePreferences.configPath)
+                        corePreferences.configPath
+                    )
                 ) {
                     LogConfig("Store AppConfig linphoneRc hash")
                     ach.storeRcHash()
@@ -242,7 +243,8 @@ class LinphoneApplication : Application(), ImageLoaderFactory {
 
                 if (LinphonePreferencesCLB.instance().UpdateFromLinphoneXmlData(
                         linphonercXmlData,
-                        config)
+                        config
+                    )
                 ) {
                     LogConfig("Store AppConfig linphoneRc XML hash")
                     ach.storeRcXmlHash()
@@ -258,7 +260,8 @@ class LinphoneApplication : Application(), ImageLoaderFactory {
                 // When older Androids are no longer supported, remove this code block!
                 if (LinphonePreferencesCLB.instance().ParseLocalXmlFileConfig(
                         config,
-                        corePreferences)
+                        corePreferences
+                    )
                 ) {
                     // If there were any config changes, also update the 'show_settings' value
                     ach.updateShowSettingsToCorePreferences(config)

--- a/app/src/main/java/org/linphone/activities/main/MainActivity.kt
+++ b/app/src/main/java/org/linphone/activities/main/MainActivity.kt
@@ -22,7 +22,6 @@ package org.linphone.activities.main
 import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.app.Dialog
-import android.app.PendingIntent
 import android.app.role.RoleManager
 import android.content.ComponentCallbacks2
 import android.content.Context

--- a/app/src/main/java/org/linphone/clb/AppConfigHelper.java
+++ b/app/src/main/java/org/linphone/clb/AppConfigHelper.java
@@ -461,8 +461,7 @@ public class AppConfigHelper {
                 BufferedInputStream bis = new BufferedInputStream(in);
 
                 // Read/Skip headers
-                int b = 0;
-                int state = 0;
+                int b, state = 0;
                 while ((b = bis.read()) != -1) {
                     if (state == 0 && b == '\r') state = 1;
                     else if (state == 1 && b == '\n') state = 2;

--- a/app/src/main/java/org/linphone/clb/AppConfigHelper.java
+++ b/app/src/main/java/org/linphone/clb/AppConfigHelper.java
@@ -461,8 +461,14 @@ public class AppConfigHelper {
                 BufferedInputStream bis = new BufferedInputStream(in);
 
                 // Read/Skip headers
-                while ((bis.read()) != -1) {
-                    // Empty, Skipping headers...
+                int b = 0;
+                int state = 0;
+                while ((b = bis.read()) != -1) {
+                    if (state == 0 && b == '\r') state = 1;
+                    else if (state == 1 && b == '\n') state = 2;
+                    else if (state == 2 && b == '\r') state = 3;
+                    else if (state == 3 && b == '\n') break;
+                    else state = 0;
                 }
 
                 StringBuilder body = new StringBuilder();

--- a/app/src/main/java/org/linphone/clb/AppConfigHelper.java
+++ b/app/src/main/java/org/linphone/clb/AppConfigHelper.java
@@ -419,8 +419,7 @@ public class AppConfigHelper {
         String tag = "provisioning";
         log("Attempting to download provisioningfile with Java Socket: " + fileUrl);
 
-        //String downloadUrl = fileUrl;
-        String downloadUrl = "http://192.168.178.49:8080/linphonerc.xml";
+        String downloadUrl = fileUrl;
         if (!downloadUrl.startsWith("http://") && !downloadUrl.startsWith("https://")) {
             downloadUrl = "http://" + downloadUrl;
         }

--- a/app/src/main/java/org/linphone/clb/AppConfigHelper.java
+++ b/app/src/main/java/org/linphone/clb/AppConfigHelper.java
@@ -2,6 +2,7 @@ package org.linphone.clb;
 
 import android.content.Context;
 import android.content.RestrictionsManager;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
@@ -14,6 +15,7 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -401,6 +403,114 @@ public class AppConfigHelper {
     private String downloadFile(final String fileUrl) {
 
         String output = "";
+        output = downloadWithJavaSocket(fileUrl);
+        if (output == null || output.isEmpty()) {
+            log("Failed to download file with Java Socket.");
+
+            output = downloadWithHttpUrlConnection(fileUrl);
+            if (output == null || output.isEmpty()) {
+                log("Failed to download file with HttpUrlConnection.");
+            }
+        }
+        return output;
+    }
+
+    public String downloadWithJavaSocket(final String fileUrl) {
+        String tag = "provisioning";
+        log("Attempting to download provisioningfile with Java Socket: " + fileUrl);
+
+        //String downloadUrl = fileUrl;
+        String downloadUrl = "http://192.168.178.49:8080/linphonerc.xml";
+        if (!downloadUrl.startsWith("http://") && !downloadUrl.startsWith("https://")) {
+            downloadUrl = "http://" + downloadUrl;
+        }
+
+        Uri uri = Uri.parse(downloadUrl);
+
+        String host = uri.getHost();
+        String path = uri.getPath();
+        int port = uri.getPort();
+
+        if (path == null || path.isEmpty()) {
+            path = "/";
+        }
+
+        System.out.println("Downloading from host: " + host + " and path: " + path);
+        log("Downloading from host: " + host + " and path: " + path);
+
+        final String downloadPath = path;
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<String> future = executor.submit(() -> {
+
+            int portNr = port == -1 ? 80 : port;
+            java.net.Socket socket = new java.net.Socket(host, portNr);
+
+            try {
+                OutputStream out = socket.getOutputStream();
+                InputStream in = socket.getInputStream();
+
+                String request =
+                        "GET " + downloadPath + " HTTP/1.1\r\n" +
+                                "Host: " + host + "\r\n" +
+                                "Connection: close\r\n" +
+                                "\r\n";
+
+                out.write(request.getBytes("UTF-8"));
+                out.flush();
+
+                BufferedInputStream bis = new BufferedInputStream(in);
+
+                // Read headers
+                ByteArrayOutputStream headerBuffer = new ByteArrayOutputStream();
+                int b;
+                int state = 0;
+
+                while ((b = bis.read()) != -1) {
+                    headerBuffer.write(b);
+
+                    if (state == 0 && b == '\r') state = 1;
+                    else if (state == 1 && b == '\n') state = 2;
+                    else if (state == 2 && b == '\r') state = 3;
+                    else if (state == 3 && b == '\n') break;
+                    else state = 0;
+                }
+
+                // String headers = headerBuffer.toString("UTF-8");
+                // System.out.println(headers);
+
+                StringBuilder body = new StringBuilder();
+
+                byte[] buffer = new byte[8192];
+                int read;
+                while ((read = bis.read(buffer)) != -1) {
+                    body.append(new String(buffer, 0, read, "UTF-8"));
+                }
+
+                return body.toString();
+
+            } catch (Exception ex) {
+                log("Java Socket download failed: " + ex.getMessage());
+                return "";
+            } finally {
+                socket.close();
+            }
+        });
+
+        try {
+            return future.get();
+        } catch (Exception ex) {
+            return "";
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    private String downloadWithHttpUrlConnection(final String fileUrl) {
+
+        System.out.println("Attempting to download provisioning file with HttpUrlConnection (only works from 'config.clb.nl'): " + fileUrl);
+
+        String output = "";
         ExecutorService executor = Executors.newSingleThreadExecutor();
 
         // Download MUST run on an non-ui thread... (Android policy)
@@ -418,7 +528,7 @@ public class AppConfigHelper {
                 connection.connect();
 
                 if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
-                    Log.i(tag, "HTTP failed. Response: " + connection.getResponseCode());
+                    log("HTTP failed. Response: " + connection.getResponseCode());
                     throw new Exception("Server returned HTTP "
                             + connection.getResponseCode()
                             + " "
@@ -445,7 +555,7 @@ public class AppConfigHelper {
                     return buffer.toString("UTF-8");
                 }
             } catch (Exception ex) {
-                Log.i(tag, "Something went wrong: " + ex.getMessage());
+                log("Something went wrong: " + ex.getMessage());
                 return null;
             } finally  {
                 if (connection != null) {
@@ -493,7 +603,7 @@ public class AppConfigHelper {
             }
 
             if (!convertToOneLinerXml(doc)) {
-                log("Failed to compress XML to a one-liner.");
+                Log.i(tag, "Failed to compress XML to a one-liner.");
             }
 
             // Clean-up done. 'transform' to a one-liner xml format
@@ -517,7 +627,7 @@ public class AppConfigHelper {
             return xmlString;
 
         } catch (Exception ex) {
-            log("Parsing configXML (provisioning) failed: " + ex.getMessage());
+            logError("Parsing configXML (provisioning) failed: " + ex.getMessage());
             return "";
         }
     }
@@ -539,7 +649,7 @@ public class AppConfigHelper {
             }
 
         } catch (Exception ex) {
-            Log.i("ach", "Compressing XML to one-liner failed: " + ex.getMessage());
+            logError("Compressing XML to one-liner failed: " + ex.getMessage());
             return false;
         }
 

--- a/app/src/main/java/org/linphone/clb/AppConfigHelper.java
+++ b/app/src/main/java/org/linphone/clb/AppConfigHelper.java
@@ -438,11 +438,11 @@ public class AppConfigHelper {
         log("Downloading from host: " + host + " and path: " + path);
 
         final String downloadPath = path;
+        final int portNr = port == -1 ? 80 : port;
 
         ExecutorService executor = Executors.newSingleThreadExecutor();
         Future<String> future = executor.submit(() -> {
 
-            int portNr = port == -1 ? 80 : port;
             java.net.Socket socket = new java.net.Socket(host, portNr);
 
             try {

--- a/app/src/main/java/org/linphone/clb/AppConfigHelper.java
+++ b/app/src/main/java/org/linphone/clb/AppConfigHelper.java
@@ -416,7 +416,6 @@ public class AppConfigHelper {
     }
 
     public String downloadWithJavaSocket(final String fileUrl) {
-        String tag = "provisioning";
         log("Attempting to download provisioningfile with Java Socket: " + fileUrl);
 
         String downloadUrl = fileUrl;
@@ -434,7 +433,6 @@ public class AppConfigHelper {
             path = "/";
         }
 
-        System.out.println("Downloading from host: " + host + " and path: " + path);
         log("Downloading from host: " + host + " and path: " + path);
 
         final String downloadPath = path;
@@ -481,7 +479,7 @@ public class AppConfigHelper {
                 return body.toString();
 
             } catch (Exception ex) {
-                log("Java Socket download failed: " + ex.getMessage());
+                logError("Java Socket download failed: " + ex.getMessage());
                 return "";
             } finally {
                 socket.close();
@@ -499,7 +497,7 @@ public class AppConfigHelper {
 
     private String downloadWithHttpUrlConnection(final String fileUrl) {
 
-        System.out.println("Attempting to download provisioning file with HttpUrlConnection (only works from 'config.clb.nl'): " + fileUrl);
+        log("Attempting to download provisioning file with HttpUrlConnection (only works from 'config.clb.nl'): " + fileUrl);
 
         String output = "";
         ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -509,8 +507,6 @@ public class AppConfigHelper {
 
             HttpURLConnection connection = null;
             try {
-                String tag = "provisioning";
-
                 URL url = new URL(fileUrl);
                 connection = (HttpURLConnection) url.openConnection();
 
@@ -573,7 +569,7 @@ public class AppConfigHelper {
             factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
             factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         } catch (Exception ex) {
-            Log.i(tag, "Failed to set XML parsing features: " + ex.getMessage());
+            logError("Failed to set XML parsing features: " + ex.getMessage());
         }
 
         factory.setExpandEntityReferences(false);
@@ -594,7 +590,7 @@ public class AppConfigHelper {
             }
 
             if (!convertToOneLinerXml(doc)) {
-                Log.i(tag, "Failed to compress XML to a one-liner.");
+                log("Failed to compress XML to a one-liner.");
             }
 
             // Clean-up done. 'transform' to a one-liner xml format

--- a/app/src/main/java/org/linphone/clb/AppConfigHelper.java
+++ b/app/src/main/java/org/linphone/clb/AppConfigHelper.java
@@ -461,23 +461,10 @@ public class AppConfigHelper {
 
                 BufferedInputStream bis = new BufferedInputStream(in);
 
-                // Read headers
-                ByteArrayOutputStream headerBuffer = new ByteArrayOutputStream();
-                int b;
-                int state = 0;
-
-                while ((b = bis.read()) != -1) {
-                    headerBuffer.write(b);
-
-                    if (state == 0 && b == '\r') state = 1;
-                    else if (state == 1 && b == '\n') state = 2;
-                    else if (state == 2 && b == '\r') state = 3;
-                    else if (state == 3 && b == '\n') break;
-                    else state = 0;
+                // Read/Skip headers
+                while ((bis.read()) != -1) {
+                    // Empty, Skipping headers...
                 }
-
-                // String headers = headerBuffer.toString("UTF-8");
-                // System.out.println(headers);
 
                 StringBuilder body = new StringBuilder();
 

--- a/app/src/main/java/org/linphone/clb/LinphonePreferencesCLB.java
+++ b/app/src/main/java/org/linphone/clb/LinphonePreferencesCLB.java
@@ -337,8 +337,8 @@ public class LinphonePreferencesCLB {
     }
 
 
-    private String sectionKey = "section";
-    private String entryKey = "entry";
+    private final String sectionKey = "section";
+    private final String entryKey = "entry";
 
     private void processParsing(XmlPullParser parser, Config lpConfig)
             throws IOException, XmlPullParserException {


### PR DESCRIPTION
SS-6815 SD-3280 Added a 'raw socket' implementation to bypass the Android 'insecure HTTP' restriction and try to download a Linphone config XML. Any IP/Hostname can be used now.

If this new download fails, the 'old' AndroidHttpConnection is tried, which can still ONLY download from config.clb.nl.

The parsing of the XML file's contents has not been changed; only the download of the file's contents.